### PR TITLE
Fix jbigkit linker flag

### DIFF
--- a/libs/libjbigkit/Makefile
+++ b/libs/libjbigkit/Makefile
@@ -29,8 +29,8 @@ define Build/Compile
 	cd $(PKG_BUILD_DIR)/libjbig; PATH=$(TARGET_PATH) $(TARGET_CC) -fPIC -g -c $(TARGET_CFLAGS) -ansi -pedantic jbig.c
 	cd $(PKG_BUILD_DIR)/libjbig; PATH=$(TARGET_PATH) $(TARGET_CC) -fPIC -g -c $(TARGET_CFLAGS) -ansi -pedantic jbig85.c
 	cd $(PKG_BUILD_DIR)/libjbig; PATH=$(TARGET_PATH) $(TARGET_CC) -fPIC -g -c $(TARGET_CFLAGS) -ansi -pedantic jbig_ar.c
-	cd $(PKG_BUILD_DIR)/libjbig; PATH=$(TARGET_PATH) $(TARGET_CC) -shared -o libjbig.so jbig.o jbig_ar.o $(TARGET_LDLAGS)
-	cd $(PKG_BUILD_DIR)/libjbig; PATH=$(TARGET_PATH) $(TARGET_CC) -shared -o libjbig85.so jbig85.o jbig_ar.o $(TARGET_LDLAGS)
+       cd $(PKG_BUILD_DIR)/libjbig; PATH=$(TARGET_PATH) $(TARGET_CC) -shared -o libjbig.so jbig.o jbig_ar.o $(TARGET_LDFLAGS)
+       cd $(PKG_BUILD_DIR)/libjbig; PATH=$(TARGET_PATH) $(TARGET_CC) -shared -o libjbig85.so jbig85.o jbig_ar.o $(TARGET_LDFLAGS)
 endef
 
 define Build/Install


### PR DESCRIPTION
## Summary
- fix typo in libjbigkit makefile so linker uses `$(TARGET_LDFLAGS)`

## Testing
- `gcc -shared -o libjbig.so jbig.o jbig_ar.o $TARGET_LDFLAGS`
- `gcc -shared -o libjbig85.so jbig85.o jbig_ar.o $TARGET_LDFLAGS`


------
https://chatgpt.com/codex/tasks/task_e_686dcf4623a4832fb9117f8ca2c90640